### PR TITLE
I made a 'Hosts' file based on dns_zones.json

### DIFF
--- a/dns_zones-hosts.txt
+++ b/dns_zones-hosts.txt
@@ -1,0 +1,45 @@
+! Title: RiiConnect24/Wiimmfi List for Users of AdGuard Home and Pi-Hole
+! Version: 10November2019v1-Beta
+! Expires: 20 days
+164.132.44.106 cfh.wapp.wii.com
+164.132.44.106 ente.wapp.wii.com
+164.132.44.106 entj.wapp.wii.com
+164.132.44.106 entu.wapp.wii.com
+164.132.44.106 miicontest.wapp.wii.com
+164.132.44.106 miicontestp.wapp.wii.com
+164.132.44.106 news.wapp.wii.com
+164.132.44.106 nwcs.wapp.wii.com
+164.132.44.106 vt.wapp.wii.com
+164.132.44.106 wus.wapp.wii.com
+164.132.44.106 weather.wapp.wii.com
+164.132.44.106 wc24.wii.com
+46.4.79.141 gamespy.com
+178.62.43.212 nas.nintendowifi.net
+165.227.235.155 dls1.wiimmfi.de
+165.227.235.155 dls2.wiimmfi.de
+165.227.235.155 dls1.riiconnect24.net
+165.227.235.155 dls2.riiconnect24.net
+165.227.235.155 dls2.pokeacer.tk
+46.4.79.141 naswii.dev.wiimmfi.de
+165.227.235.155 peerchat.gs.nintendowifi.net
+191.236.98.208 pkgdsprod.nintendo.co.jp
+178.62.43.212 pkvldtprod.nintendo.co.jp
+165.227.235.155 gamestats.gs.nintendowifi.net
+165.227.235.155 gamestats2.gs.nintendowifi.net
+69.25.139.140 conntest.nintendowifi.net
+46.4.79.141 gs.nintendowifi.net
+164.132.44.106 mariokartwii.race.gs.wiimmfi.de
+46.4.79.141 natneg1.gs.nintendowifi.net
+94.130.8.215 natneg2.gs.nintendowifi.net
+94.130.48.222 natneg3.gs.nintendowifi.net
+46.4.79.141 natneg4.gs.nintendowifi.net
+46.4.79.141 natneg5.gs.nintendowifi.net
+46.4.79.141 natneg6.gs.nintendowifi.net
+164.132.44.106 rs.nintendo.com
+164.132.44.106 ms.nintendo-europe.com
+164.132.44.106 wiirecommend.nintendo.com.au
+164.132.44.106 wii.nintendo.co.jp
+92.222.69.160 gdata.youtube.com
+178.62.43.212 flipnote.hatena.com
+165.227.235.155 syscheck.softwii.de
+165.227.235.155 syscheck.rc24.xyz


### PR DESCRIPTION
Hello, Dandelion Sprout here, an adblocking enthusiast and sporadic Nintendo DS retrogamer.

After I stumbled across this repo tonight, I realised that *dns_zones.json* contained all the necessary IP addresses and entries that I was able to make a so-called 'Hosts' file out of it. While such lists are normally used to send ad and tracking domains to an empty localhost IP, they can also be used for IP redirections in certain settings and programs.

While it's applaudable that this repo hosts an entire DNS server tool of its own, I believe there's more and more people out there who are gradually setting up Raspberry Pis with *AdGuard Home* or *Pi-Hole*; the use of which would not only be the kind of homemade server that this repo aims to provide, but also allows end-users to see all in- and out-going connections and to have a wider range of DNS server settings they can use; and some end-user even choose to make those servers available from outside their homes (though with query rate limits).

Based on https://github.com/RiiConnect24/DNS-Server/commit/ca526c69e4c0e8b6818278e6cce51c4c1091712c#diff-8572be3e9bf533ddf03c4619685c7418, a relatively simple regex to convert the entries would be `.*{.*\n.*\n.*":"(.*)",\n.*":"(.*[0-9]).*\n.*` → `\2 \1`.

Note that I made this pull before Wiimmfi's November maintenance and planned IP address change(s).