### PR TITLE
Upped Python version in workflows to 3.8.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
     - name: Obtain latest version of the repository
       uses: actions/checkout@v1
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: '3.7.6'
+        python-version: '3.8.2'
     - name: Install requirements with PIP
       run: pip install dnslib requests pyinstaller
     - name: Build DNS-Server

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
     - name: Obtain latest version of the repository
       uses: actions/checkout@v1
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: '3.7.6'
+        python-version: '3.8.2'
     - name: Install requirements with PIP
       run: pip install dnslib requests pyinstaller
     - name: Build DNS-Server


### PR DESCRIPTION
Microsoft has removed Python 3.7.7 & 3.7.6 from specific operating systems, making it impossible to use those versions for cross version compiling.