### PR TITLE
Create dns_zones.ps1

### DIFF
--- a/dns_zones-hosts.txt
+++ b/dns_zones-hosts.txt
@@ -1,6 +1,6 @@
 ! Title: RiiConnect24/Wiimmfi List for Users of AdGuard Home and Pi-Hole
 ! Version: 2020-September-14
-! Verified DNS lookup from RiiConnect24 DNS server 164.132.44.106
+! Converted from https://raw.githubusercontent.com/RiiConnect24/DNS-Server/master/dns_zones.json
 164.132.44.106 cfh.wapp.wii.com
 164.132.44.106 ente.wapp.wii.com
 164.132.44.106 entj.wapp.wii.com
@@ -12,13 +12,18 @@
 164.132.44.106 vt.wapp.wii.com
 164.132.44.106 wus.wapp.wii.com
 164.132.44.106 weather.wapp.wii.com
+164.132.44.106 wc24.wii.com
 95.217.77.151 gamespy.com
 95.217.77.151 mariokartds.available.gs.nintendowifi.net
 95.217.77.151 gpcm.gs.nintendowifi.net
 178.62.43.212 nas.nintendowifi.net
 195.201.236.139 dls1.wiimmfi.de
+165.227.235.155 dls2.wiimmfi.de
 195.201.236.139 dls1.ilostmymind.xyz
+165.227.235.155 dls1.riiconnect24.net
+165.227.235.155 dls2.riiconnect24.net
 195.20.43.101 dls2.pokeacer.tk
+95.217.77.151 naswii.dev.wiimmfi.de
 195.201.236.139 peerchat.gs.nintendowifi.net
 191.236.98.208 pkgdsprod.nintendo.co.jp
 191.236.98.208 pkvldtprod.nintendo.co.jp

--- a/dns_zones-hosts.txt
+++ b/dns_zones-hosts.txt
@@ -1,6 +1,6 @@
 ! Title: RiiConnect24/Wiimmfi List for Users of AdGuard Home and Pi-Hole
-! Version: 15November2019v1.0.1Beta
-! Expires: 20 days
+! Version: 2020-September-12
+! Verified DNS lookup from RiiConnect24 DNS server 164.132.44.106
 164.132.44.106 cfh.wapp.wii.com
 164.132.44.106 ente.wapp.wii.com
 164.132.44.106 entj.wapp.wii.com
@@ -12,25 +12,21 @@
 164.132.44.106 vt.wapp.wii.com
 164.132.44.106 wus.wapp.wii.com
 164.132.44.106 weather.wapp.wii.com
-164.132.44.106 wc24.wii.com
 95.217.77.151 gamespy.com
 95.217.77.151 mariokartds.available.gs.nintendowifi.net
 95.217.77.151 gpcm.gs.nintendowifi.net
 178.62.43.212 nas.nintendowifi.net
-165.227.235.155 dls1.wiimmfi.de
-165.227.235.155 dls2.wiimmfi.de
-165.227.235.155 dls1.riiconnect24.net
-165.227.235.155 dls2.riiconnect24.net
-165.227.235.155 dls2.pokeacer.tk
-95.217.77.151 naswii.dev.wiimmfi.de
-165.227.235.155 peerchat.gs.nintendowifi.net
+195.201.236.139 dls1.wiimmfi.de
+195.201.236.139 dls1.ilostmymind.xyz
+195.201.236.139 peerchat.gs.nintendowifi.net
 191.236.98.208 pkgdsprod.nintendo.co.jp
-178.62.43.212 pkvldtprod.nintendo.co.jp
-165.227.235.155 gamestats.gs.nintendowifi.net
-165.227.235.155 gamestats2.gs.nintendowifi.net
+191.236.98.208 pkvldtprod.nintendo.co.jp
+195.201.236.139 gamestats.gs.nintendowifi.net
+195.201.236.139 gamestats2.gs.nintendowifi.net
 69.25.139.140 conntest.nintendowifi.net
 95.217.77.151 gs.nintendowifi.net
 164.132.44.106 mariokartwii.race.gs.wiimmfi.de
+95.217.77.151 master.gs.nintendowifi.net
 95.217.77.151 natneg1.gs.nintendowifi.net
 94.130.8.215 natneg2.gs.nintendowifi.net
 94.130.48.222 natneg3.gs.nintendowifi.net
@@ -43,5 +39,5 @@
 164.132.44.106 wii.nintendo.co.jp
 92.222.69.160 gdata.youtube.com
 178.62.43.212 flipnote.hatena.com
-165.227.235.155 syscheck.softwii.de
-165.227.235.155 syscheck.rc24.xyz
+164.132.44.106 syscheck.softwii.de
+164.132.44.106 syscheck.rc24.xyz

--- a/dns_zones-hosts.txt
+++ b/dns_zones-hosts.txt
@@ -1,5 +1,5 @@
 ! Title: RiiConnect24/Wiimmfi List for Users of AdGuard Home and Pi-Hole
-! Version: 2020-September-12
+! Version: 2020-September-14
 ! Verified DNS lookup from RiiConnect24 DNS server 164.132.44.106
 164.132.44.106 cfh.wapp.wii.com
 164.132.44.106 ente.wapp.wii.com
@@ -18,6 +18,7 @@
 178.62.43.212 nas.nintendowifi.net
 195.201.236.139 dls1.wiimmfi.de
 195.201.236.139 dls1.ilostmymind.xyz
+195.20.43.101 dls2.pokeacer.tk
 195.201.236.139 peerchat.gs.nintendowifi.net
 191.236.98.208 pkgdsprod.nintendo.co.jp
 191.236.98.208 pkvldtprod.nintendo.co.jp
@@ -41,3 +42,7 @@
 178.62.43.212 flipnote.hatena.com
 164.132.44.106 syscheck.softwii.de
 164.132.44.106 syscheck.rc24.xyz
+86.1.35.134 ctgpr.chadsoft.co.uk
+195.201.236.139 ctgpr1.pokeacer.xyz
+185.216.27.189 ctgpr2.pokeacer.xyz
+164.132.44.106 ctgpr3.pokeacer.xyz

--- a/dns_zones.json
+++ b/dns_zones.json
@@ -1,212 +1,237 @@
-[  
-   {  
-      "type":"a",
-      "name":"cfh.wapp.wii.com",
-      "value":"164.132.44.106 "
-   },
-   {  
-      "type":"a",
-      "name":"ente.wapp.wii.com",
-      "value":"164.132.44.106 "
-   },
-   {  
-      "type":"a",
-      "name":"entj.wapp.wii.com",
-      "value":"164.132.44.106 "
-   },
-   {  
-      "type":"a",
-      "name":"entu.wapp.wii.com",
-      "value":"164.132.44.106 "
-   },
-   {  
-      "type":"a",
-      "name":"miicontest.wapp.wii.com",
-      "value":"164.132.44.106 "
-   },
-   {  
-      "type":"a",
-      "name":"miicontestp.wapp.wii.com",
-      "value":"164.132.44.106 "
-   },
-   {  
-      "type":"a",
-      "name":"news.wapp.wii.com",
-      "value":"164.132.44.106 "
-   },
-   {  
-      "type":"a",
-      "name":"nwcs.wapp.wii.com",
-      "value":"164.132.44.106 "
-   },
-   {  
-      "type":"a",
-      "name":"vt.wapp.wii.com",
-      "value":"164.132.44.106 "
-   },
-   {  
-      "type":"a",
-      "name":"wus.wapp.wii.com",
-      "value":"164.132.44.106 "
-   },
-   {  
-      "type":"a",
-      "name":"weather.wapp.wii.com",
-      "value":"164.132.44.106 "
-   },
-   {  
-      "type":"a",
-      "name":"wc24.wii.com",
-      "value":"164.132.44.106 "
-   },
-   {  
-      "type":"a",
-      "name":"gamespy.com",
-      "value":"95.217.77.151 "
+[
+   {
+      "type": "a",
+      "name": "cfh.wapp.wii.com",
+      "value": "164.132.44.106"
    },
    {
-      "type":"a",
-      "name":"mariokartds.available.gs.nintendowifi.net",
-      "value":"95.217.77.151 "
+      "type": "a",
+      "name": "ente.wapp.wii.com",
+      "value": "164.132.44.106"
    },
    {
-      "type":"a",
-      "name":"gpcm.gs.nintendowifi.net",
-      "value":"95.217.77.151 "
-   },
-   {  
-      "type":"a",
-      "name":"nas.nintendowifi.net",
-      "value":"178.62.43.212 "
-   },
-   {  
-      "type":"a",
-      "name":"dls1.wiimmfi.de",
-      "value":"195.201.236.139 "
-   },
-   {  
-      "type":"a",
-      "name":"dls1.ilostmymind.xyz",
-      "value":"195.201.236.139 "
-   },
-   {  
-      "type":"a",
-      "name":"naswii.dev.wiimmfi.de",
-      "value":"95.217.77.151 "
-   },
-   {  
-      "type":"a",
-      "name":"peerchat.gs.nintendowifi.net",
-      "value":"195.201.236.139 "
-   },
-   {  
-      "type":"a",
-      "name":"pkgdsprod.nintendo.co.jp",
-      "value":"191.236.98.208"
-   },
-   {  
-      "type":"a",
-      "name":"pkvldtprod.nintendo.co.jp",
-      "value":"178.62.43.212"
-   },
-   {  
-      "type":"a",
-      "name":"gamestats.gs.nintendowifi.net",
-      "value":"195.201.236.139 "
-   },
-   {  
-      "type":"a",
-      "name":"gamestats2.gs.nintendowifi.net",
-      "value":"195.201.236.139 "
-   },
-   {  
-      "type":"a",
-      "name":"conntest.nintendowifi.net",
-      "value":"69.25.139.140"
-   },
-   {  
-      "type":"a",
-      "name":"gs.nintendowifi.net",
-      "value":"95.217.77.151"
-   },
-   {  
-      "type":"a",
-      "name":"mariokartwii.race.gs.wiimmfi.de",
-      "value":"164.132.44.106"
+      "type": "a",
+      "name": "entj.wapp.wii.com",
+      "value": "164.132.44.106"
    },
    {
-      "type":"a",
-      "name":"master.gs.nintendowifi.net",
-      "value":"95.217.77.151"
+      "type": "a",
+      "name": "entu.wapp.wii.com",
+      "value": "164.132.44.106"
    },
-   {  
-      "type":"a",
-      "name":"natneg1.gs.nintendowifi.net",
-      "value":"95.217.77.151"
+   {
+      "type": "a",
+      "name": "miicontest.wapp.wii.com",
+      "value": "164.132.44.106"
    },
-   {  
-      "type":"a",
-      "name":"natneg2.gs.nintendowifi.net",
-      "value":"94.130.8.215"
+   {
+      "type": "a",
+      "name": "miicontestp.wapp.wii.com",
+      "value": "164.132.44.106"
    },
-   {  
-      "type":"a",
-      "name":"natneg3.gs.nintendowifi.net",
-      "value":"94.130.48.222"
+   {
+      "type": "a",
+      "name": "news.wapp.wii.com",
+      "value": "164.132.44.106"
    },
-   {  
-      "type":"a",
-      "name":"natneg4.gs.nintendowifi.net",
-      "value":"95.217.77.151"
+   {
+      "type": "a",
+      "name": "nwcs.wapp.wii.com",
+      "value": "164.132.44.106"
    },
-   {  
-      "type":"a",
-      "name":"natneg5.gs.nintendowifi.net",
-      "value":"95.217.77.151"
+   {
+      "type": "a",
+      "name": "vt.wapp.wii.com",
+      "value": "164.132.44.106"
    },
-   {  
-      "type":"a",
-      "name":"natneg6.gs.nintendowifi.net",
-      "value":"95.217.77.151"
+   {
+      "type": "a",
+      "name": "wus.wapp.wii.com",
+      "value": "164.132.44.106"
    },
-   {  
-      "type":"a",
-      "name":"rs.nintendo.com",
-      "value":"164.132.44.106"
+   {
+      "type": "a",
+      "name": "weather.wapp.wii.com",
+      "value": "164.132.44.106"
    },
-   {  
-      "type":"a",
-      "name":"ms.nintendo-europe.com",
-      "value":"164.132.44.106"
+   {
+      "type": "a",
+      "name": "wc24.wii.com",
+      "value": "164.132.44.106"
    },
-   {  
-      "type":"a",
-      "name":"wiirecommend.nintendo.com.au",
-      "value":"164.132.44.106"
+   {
+      "type": "a",
+      "name": "gamespy.com",
+      "value": "95.217.77.151"
    },
-   {  
-      "type":"a",
-      "name":"wii.nintendo.co.jp",
-      "value":"164.132.44.106"
+   {
+      "type": "a",
+      "name": "mariokartds.available.gs.nintendowifi.net",
+      "value": "95.217.77.151"
    },
-   {  
-      "type":"a",
-      "name":"gdata.youtube.com",
-      "value":"92.222.69.160"
+   {
+      "type": "a",
+      "name": "gpcm.gs.nintendowifi.net",
+      "value": "95.217.77.151"
    },
-   {  
-      "type":"a",
-      "name":"flipnote.hatena.com",
-      "value":"178.62.43.212"
+   {
+      "type": "a",
+      "name": "nas.nintendowifi.net",
+      "value": "178.62.43.212"
    },
-   {  
-      "type":"a",
-      "name":"syscheck.softwii.de",
-      "value":"195.201.236.139"
+   {
+      "type": "a",
+      "name": "dls1.wiimmfi.de",
+      "value": "195.201.236.139"
    },
-   {  
-      "type":"a",
-      "name":"syscheck.rc24.xyz",
-      "value":"195.201.236.139"
+   {
+      "type": "a",
+      "name": "dls1.ilostmymind.xyz",
+      "value": "195.201.236.139"
+   },
+   {
+      "type": "a",
+      "name": "dls2.pokeacer.tk",
+      "value": "195.20.43.101"
+   }
+   {
+      "type": "a",
+      "name": "naswii.dev.wiimmfi.de",
+      "value": "95.217.77.151"
+   },
+   {
+      "type": "a",
+      "name": "peerchat.gs.nintendowifi.net",
+      "value": "195.201.236.139"
+   },
+   {
+      "type": "a",
+      "name": "pkgdsprod.nintendo.co.jp",
+      "value": "191.236.98.208"
+   },
+   {
+      "type": "a",
+      "name": "pkvldtprod.nintendo.co.jp",
+      "value": "191.236.98.208"
+   },
+   {
+      "type": "a",
+      "name": "gamestats.gs.nintendowifi.net",
+      "value": "195.201.236.139"
+   },
+   {
+      "type": "a",
+      "name": "gamestats2.gs.nintendowifi.net",
+      "value": "195.201.236.139"
+   },
+   {
+      "type": "a",
+      "name": "conntest.nintendowifi.net",
+      "value": "69.25.139.140"
+   },
+   {
+      "type": "a",
+      "name": "gs.nintendowifi.net",
+      "value": "95.217.77.151"
+   },
+   {
+      "type": "a",
+      "name": "mariokartwii.race.gs.wiimmfi.de",
+      "value": "164.132.44.106"
+   },
+   {
+      "type": "a",
+      "name": "master.gs.nintendowifi.net",
+      "value": "95.217.77.151"
+   },
+   {
+      "type": "a",
+      "name": "natneg1.gs.nintendowifi.net",
+      "value": "95.217.77.151"
+   },
+   {
+      "type": "a",
+      "name": "natneg2.gs.nintendowifi.net",
+      "value": "94.130.8.215"
+   },
+   {
+      "type": "a",
+      "name": "natneg3.gs.nintendowifi.net",
+      "value": "94.130.48.222"
+   },
+   {
+      "type": "a",
+      "name": "natneg4.gs.nintendowifi.net",
+      "value": "95.217.77.151"
+   },
+   {
+      "type": "a",
+      "name": "natneg5.gs.nintendowifi.net",
+      "value": "95.217.77.151"
+   },
+   {
+      "type": "a",
+      "name": "natneg6.gs.nintendowifi.net",
+      "value": "95.217.77.151"
+   },
+   {
+      "type": "a",
+      "name": "rs.nintendo.com",
+      "value": "164.132.44.106"
+   },
+   {
+      "type": "a",
+      "name": "ms.nintendo-europe.com",
+      "value": "164.132.44.106"
+   },
+   {
+      "type": "a",
+      "name": "wiirecommend.nintendo.com.au",
+      "value": "164.132.44.106"
+   },
+   {
+      "type": "a",
+      "name": "wii.nintendo.co.jp",
+      "value": "164.132.44.106"
+   },
+   {
+      "type": "a",
+      "name": "gdata.youtube.com",
+      "value": "92.222.69.160"
+   },
+   {
+      "type": "a",
+      "name": "flipnote.hatena.com",
+      "value": "178.62.43.212"
+   },
+   {
+      "type": "a",
+      "name": "syscheck.softwii.de",
+      "value": "164.132.44.106"
+   },
+   {
+      "type": "a",
+      "name": "syscheck.rc24.xyz",
+      "value": "164.132.44.106"
+   },
+   {
+      "type": "a",
+      "name": "ctgpr.chadsoft.co.uk",
+      "value": "86.1.35.134"
+   },
+   {
+      "type": "a",
+      "name": "ctgpr1.pokeacer.xyz",
+      "value": "195.201.236.139"
+   },
+   {
+      "type": "a",
+      "name": "ctgpr2.pokeacer.xyz",
+      "value": "185.216.27.189"
+   },
+   {
+      "type": "a",
+      "name": "ctgpr3.pokeacer.xyz",
+      "value": "164.132.44.106"
    }
 ]

--- a/dns_zones.json
+++ b/dns_zones.json
@@ -86,14 +86,29 @@
    },
    {
       "type": "a",
+      "name": "dls2.wiimmfi.de",
+      "value": "165.227.235.155"
+   },
+   {
+      "type": "a",
       "name": "dls1.ilostmymind.xyz",
       "value": "195.201.236.139"
    },
    {
       "type": "a",
+      "name": "dls1.riiconnect24.net",
+      "value": "165.227.235.155"
+   },
+   {
+      "type": "a",
+      "name": "dls2.riiconnect24.net",
+      "value": "165.227.235.155"
+   },
+   {
+      "type": "a",
       "name": "dls2.pokeacer.tk",
       "value": "195.20.43.101"
-   }
+   },
    {
       "type": "a",
       "name": "naswii.dev.wiimmfi.de",

--- a/dns_zones.ps1
+++ b/dns_zones.ps1
@@ -1,0 +1,37 @@
+<# RiiConnect24 DNS-Server https://github.com/RiiConnect24/DNS-Server
+PowerShell script updates dns_zones-hosts.txt file from dns_zones.json file.
+Generates two files to replace: https://raw.githubusercontent.com/RiiConnect24/DNS-Server/master/dns_zones-hosts.txt
+First uses IP address in json file. Second uses domains in json file and looks up IP addresses from RC24 DNS server.
+#>
+
+# Set variables.
+$date = Get-Date -Format "yyyy-MMMM-dd"
+$header = "! Title: RiiConnect24/Wiimmfi List for Users of AdGuard Home and Pi-Hole`n! Version: $date"
+$DNSjson = "https://raw.githubusercontent.com/RiiConnect24/DNS-Server/master/dns_zones.json"
+$new_converted = "dns_zones-hosts.txt"
+$new_verified = "dns_zones-hosts(verified).txt"
+$RC24DNS = "164.132.44.106"
+
+# Converts json format to array.
+$dns_zones = (New-Object System.Net.WebClient).DownloadString($DNSjson) | ConvertFrom-Json
+
+# Recreates hosts file from latest json file.
+Out-File $new_converted -InputObject $header 
+Out-File $new_converted -Append -InputObject "! Converted from https://raw.githubusercontent.com/RiiConnect24/DNS-Server/master/dns_zones.json"
+$dns_zones | ForEach-Object {
+    $_.value, $_.name -join ' ' | Out-File $new_converted -Append
+}
+
+# Verifies DNS records
+Out-File $new_verified -InputObject $header
+Out-File $new_verified -Append -InputObject "! Verified DNS lookup from RiiConnect24 DNS server $RC24DNS"
+$dns_zones | ForEach-Object {
+    $VerifiedIP = Resolve-DnsName -Name $_.name -DnsOnly -Server $RC24DNS
+    if ($VerifiedIP.IP4Address -eq $null) {
+        Write-Host "RiiConnect24 DNS server $RC24DNS does not have an IP address for", $_.name -ForegroundColor Red
+        $TestIP = Resolve-DnsName -Name $_.name -DnsOnly -Server 1.1.1.1
+        if ($TestIP.IP4Address -eq $null) { Write-Host "CloudFlare DNS server 1.1.1.1 confirms domain is unknown." }
+        else { Write-Host "CloudFlare DNS server 1.1.1.1 reports IP address as", $TestIP.IP4Address -join ' ' }
+    }
+    else { $VerifiedIP.IP4Address, $_.name -join ' ' | Out-File $new_verified -Append }
+}


### PR DESCRIPTION
Since 'dns_zones.json' is updated more often than 'dns_zones-hosts.txt' with server changes, I wrote this PowerShell script to convert the json format to hosts. Additionally, it queries the domains against the RC24 DNS server for current IP addresses from there. There are a few discrepancies between the two so if the RiiConnect24 DNS server is gold, then the following domains need to be reviewed.
- wc24.wii.com
- naswii.dev.wiimmfi.de
- pkvldtprod.nintendo.co.jp
- syscheck.softwii.de
- syscheck.rc24.xyz