### PR TITLE
Update mariokartwii.race.gs.wiimmfi.de address

### DIFF
--- a/dns_zones-hosts.txt
+++ b/dns_zones-hosts.txt
@@ -20,7 +20,7 @@
 178.62.43.212 it-ds.pokemon-gl.com
 178.62.43.212 ko-ds.pokemon-gl.com
 104.248.0.110 maintenance.hatena.ne.jp
-167.86.108.126 mariokartwii.race.gs.wiimmfi.de
+188.34.177.217 mariokartwii.race.gs.wiimmfi.de
 95.217.77.181 master.gs.nintendowifi.net
 167.86.108.126 miicontest.wapp.wii.com
 167.86.108.126 miicontestp.wapp.wii.com

--- a/dns_zones.json
+++ b/dns_zones.json
@@ -112,7 +112,7 @@
    {
       "type":"a",
       "name":"mariokartwii.race.gs.wiimmfi.de",
-      "value":"167.86.108.126"
+      "value":"188.34.177.217"
    },
    {
       "type":"a",


### PR DESCRIPTION
This is outdated and causes competition fetching to fail when using RC24's DNS. This also affects the production RiiConnect24 DNS. I was able to manually fetch the latest MKWii competition with this patch in place.